### PR TITLE
Add localhost support for getUserMedia permission handling 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ on the `WKWebView`. Whenever the JS code in the web view calls
 `navigator.mediaDevices.getUserMedia`, the web view asks the delegate for a
 “permission decision” by sending it a
 [`webView:requestMediaCapturePermissionForOrigin:initiatedByFrame:type:decisionHandler:`](https://developer.apple.com/documentation/webkit/wkuidelegate/3763087-webview?language=objc)
-message. The plugin checks the protocol of the origin, and if it’s `file` then
-it makes an “allow” decision, which suppresses the permission dialog. For all
-other origins it makes the default “prompt” decision, so if you’re running
-`getUserMedia` from web pages loaded from outside the app, they will continue to
-prompt for permission. If you need to allow that, feel free to fork this plugin.
+message. The plugin checks the protocol of the origin, and if it’s `file` or
+`localhost` (http/https), or `127.0.0.1` (http/https) then it makes an "allow"
+decision, which suppresses the permission dialog. For all other origins it makes
+the default “prompt” decision, so if you’re running `getUserMedia` from web
+pages loaded from outside the app, they will continue to prompt for permission.
+If you need to allow that, feel free to fork this plugin.
 
 Note that all other `WKUIDelegate` messages are forwarded to the original
 delegate that was in place when this plugin is loaded, so the other functions of

--- a/src/PermitGetUserMedia.m
+++ b/src/PermitGetUserMedia.m
@@ -28,8 +28,14 @@
                                       type: (WKMediaCaptureType) type
                            decisionHandler: (void (^)(WKPermissionDecision decision)) decisionHandler
 {
-    if ([origin.protocol isEqualToString:@"file"]) {
-        NSLog(@"Supressing media permission request for file origin");
+    BOOL isFileOrigin = [origin.protocol isEqualToString:@"file"];
+    BOOL isLocalhostOrigin = ([origin.protocol isEqualToString:@"http"] || [origin.protocol isEqualToString:@"https"]) && 
+                            ([origin.host isEqualToString:@"localhost"] || [origin.host isEqualToString:@"127.0.0.1"]);
+    
+    if (isFileOrigin || isLocalhostOrigin) {
+        NSString *originType = isFileOrigin ? @"file" : 
+                              [origin.host isEqualToString:@"localhost"] ? @"localhost" : @"127.0.0.1";
+        NSLog(@"Supressing media permission request for %@ origin", originType);
         decisionHandler(WKPermissionDecisionGrant);
     } else {
         decisionHandler(WKPermissionDecisionPrompt);


### PR DESCRIPTION
* Add localhost support to media permission handling
* Add 127.0.0.1 support and improve origin type logging


---
## original issue

Every time I hit the recording button, I have to give permission.

<img src="https://github.com/user-attachments/assets/80fb39e1-68b3-45c4-86d8-4c9ded4de15d" width="400">

### solutions 

After doing some deep research: https://chatgpt.com/share/688483bd-ea70-8004-8f7b-8f69ce44008b

The simplest and straightforward approach would be to update this plug-in to support local host: https://github.com/tokenized/cordova-plugin-ios-permit-getusermedia

In practice, using this plugin means the user will see the normal iOS camera/mic permission request once (the system prompt governed by your app’s NSCameraUsageDescription/NSMicrophoneUsageDescription), but will not be repeatedly prompted by the WKWebView “localhost” permission on each app launch.

This plug-in deals with permissions, but also exposes the RTC https://github.com/cordova-rtc/cordova-plugin-iosrtc